### PR TITLE
Improve PDF to JSON workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,25 +79,24 @@ pip install -r requirements.txt
 ```
 
 ### 📄 (Option) Convert PDF to JSON
-The following process describes how to convert a paper PDF into JSON format.  
-If you have access to the LaTeX source and plan to use it with PaperCoder, you may skip this step and proceed to [🚀 Running PaperCoder](#-running-papercoder).  
-Note: In our experiments, we converted all paper PDFs to JSON format.
+The following process describes how to convert a paper PDF into JSON format.
+If you have access to the LaTeX source and plan to use it with PaperCoder, you may skip this step and proceed to [🚀 Running PaperCoder](#-running-papercoder).
 
-1. Clone the `s2orc-doc2json` repository to convert your PDF file into a structured JSON format.  
-   (For detailed configuration, please refer to the [official repository](https://github.com/allenai/s2orc-doc2json).)
+Note: In our experiments, we converted all paper PDFs to JSON format. The original workflow relied on the
+[`s2orc-doc2json`](https://github.com/allenai/s2orc-doc2json) repository. As of 2025 more capable open-source
+libraries exist. We provide two approaches below.
+
+#### Legacy approach (compatible with older instructions)
+
+1. Clone `s2orc-doc2json` and run its processing service:
 
 ```bash
 git clone https://github.com/allenai/s2orc-doc2json.git
-```
-
-2. Run the PDF processing service.
-
-```bash
 cd ./s2orc-doc2json/grobid-0.7.3
 ./gradlew run
 ```
 
-3. Convert your PDF into JSON format.
+2. Convert the PDF into JSON format using the bundled script:
 
 ```bash
 mkdir -p ./s2orc-doc2json/output_dir/paper_coder
@@ -106,6 +105,29 @@ python ./s2orc-doc2json/doc2json/grobid2json/process_pdf.py \
     -t ./s2orc-doc2json/temp_dir/ \
     -o ./s2orc-doc2json/output_dir/paper_coder
 ```
+
+#### Hybrid approach (recommended for 2025)
+
+1. Install modern PDF processing libraries.
+
+```bash
+pip install PyMuPDF pdfplumber layoutparser
+```
+
+2. Ensure the latest `grobid` server (v0.8 or later) is running.
+
+3. Use the script [`codes/pdf_to_json_hybrid.py`](./codes/pdf_to_json_hybrid.py) to combine
+page-level text extraction with metadata from `grobid` and produce a single JSON file:
+
+```bash
+python codes/pdf_to_json_hybrid.py \
+    --pdf_path ${PDF_PATH} \
+    --output_json ./paper_coder_output/paper.json \
+    --grobid_url http://localhost:8070
+```
+
+This hybrid pipeline leverages modern layout analysis tools for accurate page content
+while still using `grobid` for reliable metadata extraction.
 
 ### 🚀 Running PaperCoder
 - Note: The following command runs example paper ([Attention Is All You Need](https://arxiv.org/abs/1706.03762)).  

--- a/codes/pdf_to_json_hybrid.py
+++ b/codes/pdf_to_json_hybrid.py
@@ -1,0 +1,63 @@
+"""Hybrid PDF to JSON conversion script.
+
+This script demonstrates a simple pipeline that combines modern
+PDF text extraction libraries with metadata extracted from a running
+GROBID server. The resulting JSON contains page level text and the
+TEI XML from GROBID.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pdfplumber  # type: ignore
+
+
+def extract_pages(pdf_path: str):
+    """Extract text from each page using pdfplumber."""
+    pages = []
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            pages.append(page.extract_text() or "")
+    return pages
+
+
+def call_grobid(pdf_path: str, out_dir: str, grobid_url: str):
+    """Call the GROBID service to obtain TEI XML."""
+    cmd = [
+        "grobid-client",
+        "--input",
+        pdf_path,
+        "--output",
+        out_dir,
+        "--url",
+        grobid_url,
+        "--processFulltext",
+    ]
+    subprocess.run(cmd, check=True)
+    tei_file = Path(out_dir) / f"{Path(pdf_path).stem}.tei.xml"
+    return tei_file
+
+
+def build_json(pdf_path: str, out_json: str, grobid_url: str):
+    os.makedirs("temp_grobid", exist_ok=True)
+    tei_file = call_grobid(pdf_path, "temp_grobid", grobid_url)
+    pages = extract_pages(pdf_path)
+    data = {"pages": pages}
+    if tei_file.exists():
+        data["tei_xml"] = tei_file.read_text()
+    with open(out_json, "w") as f:
+        json.dump(data, f)
+    print(f"[SAVED] {out_json}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Hybrid PDF to JSON converter")
+    parser.add_argument("--pdf_path", required=True)
+    parser.add_argument("--output_json", required=True)
+    parser.add_argument("--grobid_url", default="http://localhost:8070")
+    args = parser.parse_args()
+
+    build_json(args.pdf_path, args.output_json, args.grobid_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai>=1.65.4
 vllm>=0.6.4.post1
 transformers>=4.46.3
 tiktoken>=0.9.0
+pdfplumber>=0.11.0


### PR DESCRIPTION
## Summary
- document a modern hybrid PDF-to-JSON conversion approach
- add `pdf_to_json_hybrid.py` example script
- include `pdfplumber` in requirements

## Testing
- `python -m py_compile codes/pdf_to_json_hybrid.py`
