### PR TITLE
Add simplified PDF-to-JSON pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ python codes/pdf_to_json_hybrid.py \
 This hybrid pipeline leverages modern layout analysis tools for accurate page content
 while still using `grobid` for reliable metadata extraction.
 
+#### Simple approach (no `grobid`)
+
+1. Install lightweight dependencies.
+
+```bash
+pip install PyMuPDF pdf2image pytesseract camelot-py
+```
+
+2. Run the script [`codes/pdf_to_json_simple.py`](./codes/pdf_to_json_simple.py):
+
+```bash
+python codes/pdf_to_json_simple.py \
+    --pdf_path ${PDF_PATH} \
+    --output_json ./paper_coder_output/paper.json
+```
+
+This method relies solely on PyMuPDF and OCR, optionally using `camelot` to
+extract tables.
+
 ### 🚀 Running PaperCoder
 - Note: The following command runs example paper ([Attention Is All You Need](https://arxiv.org/abs/1706.03762)).  
   If you want to run PaperCoder on your own paper, please modify the environment variables accordingly.

--- a/codes/pdf_to_json_simple.py
+++ b/codes/pdf_to_json_simple.py
@@ -1,0 +1,78 @@
+"""Simple PDF to JSON conversion script.
+
+This script provides a lightweight pipeline for extracting
+text and tables from a PDF without requiring GROBID or
+other complex services. It relies on PyMuPDF for direct
+text extraction and falls back to Tesseract OCR when
+no text is detected on a page. Detected tables are
+extracted with camelot if available.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import fitz  # PyMuPDF
+from pdf2image import convert_from_path
+import pytesseract
+
+try:
+    import camelot  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    camelot = None
+
+
+def extract_page_text(page):
+    """Return text from a PyMuPDF page, using OCR if needed."""
+    text = page.get_text()
+    if text.strip():
+        return text
+    # Fallback to OCR
+    images = convert_from_path(
+        page.parent.name,
+        dpi=300,
+        first_page=page.number + 1,
+        last_page=page.number + 1,
+    )
+    return pytesseract.image_to_string(images[0])
+
+
+def extract_tables(pdf_path: str, page_number: int):
+    """Extract tables from the specified page using camelot if available."""
+    if camelot is None:
+        return []
+    try:
+        tables = camelot.read_pdf(pdf_path, pages=str(page_number))
+        return [t.df.to_dict() for t in tables]
+    except Exception:
+        return []
+
+
+def extract_pages(pdf_path: str):
+    """Process all pages in the PDF and collect text and tables."""
+    doc = fitz.open(pdf_path)
+    pages = []
+    for page in doc:
+        page_num = page.number + 1
+        text = extract_page_text(page)
+        tables = extract_tables(pdf_path, page_num)
+        pages.append({"page_number": page_num, "text": text, "tables": tables})
+    return pages
+
+
+def build_json(pdf_path: str, out_json: str):
+    pages = extract_pages(pdf_path)
+    data = {"pages": pages}
+    Path(out_json).write_text(json.dumps(data, indent=2))
+    print(f"[SAVED] {out_json}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Simple PDF to JSON converter without GROBID"
+    )
+    parser.add_argument("--pdf_path", required=True)
+    parser.add_argument("--output_json", required=True)
+    args = parser.parse_args()
+
+    build_json(args.pdf_path, args.output_json)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ vllm>=0.6.4.post1
 transformers>=4.46.3
 tiktoken>=0.9.0
 pdfplumber>=0.11.0
+camelot-py>=0.11
+pdf2image>=1.16.3
+PyMuPDF>=1.23.7
+pytesseract>=0.3.10


### PR DESCRIPTION
## Summary
- add `pdf_to_json_simple.py` for lightweight conversion without GROBID
- document the simple approach in `README`
- expand dependencies in `requirements.txt`

## Testing
- `python -m py_compile codes/pdf_to_json_simple.py`