### PR TITLE
Add unit tests for simple PDF to JSON script

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,25 @@ python codes/pdf_to_json_hybrid.py \
 This hybrid pipeline leverages modern layout analysis tools for accurate page content
 while still using `grobid` for reliable metadata extraction.
 
+#### Simple approach (no `grobid`)
+
+1. Install lightweight dependencies.
+
+```bash
+pip install PyMuPDF pdf2image pytesseract camelot-py
+```
+
+2. Run the script [`codes/pdf_to_json_simple.py`](./codes/pdf_to_json_simple.py):
+
+```bash
+python codes/pdf_to_json_simple.py \
+    --pdf_path ${PDF_PATH} \
+    --output_json ./paper_coder_output/paper.json
+```
+
+This method relies solely on PyMuPDF and OCR, optionally using `camelot` to
+extract tables.
+
 ### 🚀 Running PaperCoder
 - Note: The following command runs example paper ([Attention Is All You Need](https://arxiv.org/abs/1706.03762)).  
   If you want to run PaperCoder on your own paper, please modify the environment variables accordingly.

--- a/codes/pdf_to_json_simple.py
+++ b/codes/pdf_to_json_simple.py
@@ -1,0 +1,78 @@
+"""Simple PDF to JSON conversion script.
+
+This script provides a lightweight pipeline for extracting
+text and tables from a PDF without requiring GROBID or
+other complex services. It relies on PyMuPDF for direct
+text extraction and falls back to Tesseract OCR when
+no text is detected on a page. Detected tables are
+extracted with camelot if available.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import fitz  # PyMuPDF
+from pdf2image import convert_from_path
+import pytesseract
+
+try:
+    import camelot  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    camelot = None
+
+
+def extract_page_text(page):
+    """Return text from a PyMuPDF page, using OCR if needed."""
+    text = page.get_text()
+    if text.strip():
+        return text
+    # Fallback to OCR
+    images = convert_from_path(
+        page.parent.name,
+        dpi=300,
+        first_page=page.number + 1,
+        last_page=page.number + 1,
+    )
+    return pytesseract.image_to_string(images[0])
+
+
+def extract_tables(pdf_path: str, page_number: int):
+    """Extract tables from the specified page using camelot if available."""
+    if camelot is None:
+        return []
+    try:
+        tables = camelot.read_pdf(pdf_path, pages=str(page_number))
+        return [t.df.to_dict() for t in tables]
+    except Exception:
+        return []
+
+
+def extract_pages(pdf_path: str):
+    """Process all pages in the PDF and collect text and tables."""
+    doc = fitz.open(pdf_path)
+    pages = []
+    for page in doc:
+        page_num = page.number + 1
+        text = extract_page_text(page)
+        tables = extract_tables(pdf_path, page_num)
+        pages.append({"page_number": page_num, "text": text, "tables": tables})
+    return pages
+
+
+def build_json(pdf_path: str, out_json: str):
+    pages = extract_pages(pdf_path)
+    data = {"pages": pages}
+    Path(out_json).write_text(json.dumps(data, indent=2))
+    print(f"[SAVED] {out_json}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Simple PDF to JSON converter without GROBID"
+    )
+    parser.add_argument("--pdf_path", required=True)
+    parser.add_argument("--output_json", required=True)
+    args = parser.parse_args()
+
+    build_json(args.pdf_path, args.output_json)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ vllm>=0.6.4.post1
 transformers>=4.46.3
 tiktoken>=0.9.0
 pdfplumber>=0.11.0
+camelot-py>=0.11
+pdf2image>=1.16.3
+PyMuPDF>=1.23.7
+pytesseract>=0.3.10

--- a/tests/test_pdf_to_json_simple.py
+++ b/tests/test_pdf_to_json_simple.py
@@ -1,0 +1,106 @@
+import os
+import sys
+from types import SimpleNamespace
+import json
+import builtins
+
+# Ensure the repository root is on sys.path so that `codes` is importable
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+import pytest
+
+# Since pdf_to_json_simple imports modules that may not be available
+# we create dummy modules if needed
+
+modules_to_mock = {}
+for name in ["fitz", "pdf2image", "pytesseract"]:
+    if name not in sys.modules:
+        modules_to_mock[name] = SimpleNamespace()
+        sys.modules[name] = modules_to_mock[name]
+
+# Provide minimal APIs for mocked modules
+if hasattr(sys.modules["pdf2image"], "convert_from_path") is False:
+    sys.modules["pdf2image"].convert_from_path = lambda *a, **k: ["img"]
+
+if hasattr(sys.modules["pytesseract"], "image_to_string") is False:
+    sys.modules["pytesseract"].image_to_string = lambda img: "ocr"
+
+import codes.pdf_to_json_simple as pdf_simple
+
+# restore modules after import
+def teardown_module(module):
+    for name, obj in modules_to_mock.items():
+        sys.modules.pop(name, None)
+
+
+def test_extract_page_text_direct():
+    page = SimpleNamespace(get_text=lambda: "hello", parent=SimpleNamespace(name="a.pdf"), number=0)
+    assert pdf_simple.extract_page_text(page) == "hello"
+
+
+def test_extract_page_text_ocr(monkeypatch):
+    page = SimpleNamespace(get_text=lambda: "", parent=SimpleNamespace(name="b.pdf"), number=0)
+    called = {}
+
+    def fake_convert(pdf_path, dpi=300, first_page=None, last_page=None):
+        called["convert"] = True
+        return ["img"]
+
+    def fake_ocr(img):
+        called["ocr"] = True
+        return "scanned"
+
+    monkeypatch.setattr(pdf_simple, "convert_from_path", fake_convert)
+    monkeypatch.setattr(pdf_simple, "pytesseract", SimpleNamespace(image_to_string=fake_ocr))
+
+    text = pdf_simple.extract_page_text(page)
+    assert text == "scanned"
+    assert called.get("convert") and called.get("ocr")
+
+
+def test_extract_tables_no_camelot(monkeypatch):
+    monkeypatch.setattr(pdf_simple, "camelot", None)
+    assert pdf_simple.extract_tables("file.pdf", 1) == []
+
+
+def test_extract_tables_with_camelot(monkeypatch):
+    class DummyTable:
+        def __init__(self, value):
+            self.df = SimpleNamespace(to_dict=lambda: {"table": value})
+    class DummyCamelot:
+        def read_pdf(self, pdf_path, pages):
+            assert pdf_path == "file.pdf"
+            assert pages == "2"
+            return [DummyTable(1), DummyTable(2)]
+    monkeypatch.setattr(pdf_simple, "camelot", DummyCamelot())
+    tables = pdf_simple.extract_tables("file.pdf", 2)
+    assert tables == [{"table": 1}, {"table": 2}]
+
+
+def test_extract_pages(monkeypatch):
+    class DummyPage:
+        def __init__(self, num):
+            self.number = num
+            self.parent = SimpleNamespace(name="c.pdf")
+        def get_text(self):
+            return f"text{self.number}"
+    class DummyDoc:
+        def __iter__(self):
+            return iter([DummyPage(0), DummyPage(1)])
+    monkeypatch.setattr(pdf_simple, "fitz", SimpleNamespace(open=lambda x: DummyDoc()))
+    monkeypatch.setattr(pdf_simple, "extract_tables", lambda path, page_number: [page_number])
+    pages = pdf_simple.extract_pages("c.pdf")
+    assert pages == [
+        {"page_number": 1, "text": "text0", "tables": [1]},
+        {"page_number": 2, "text": "text1", "tables": [2]},
+    ]
+
+
+def test_build_json(tmp_path, monkeypatch):
+    sample_pages = [{"page_number": 1, "text": "a", "tables": []}]
+    monkeypatch.setattr(pdf_simple, "extract_pages", lambda path: sample_pages)
+    out_json = tmp_path / "out.json"
+    pdf_simple.build_json("x.pdf", out_json)
+    data = json.loads(out_json.read_text())
+    assert data == {"pages": sample_pages}


### PR DESCRIPTION
## Summary
- add test suite for `pdf_to_json_simple.py`

## Testing
- `python -m py_compile codes/pdf_to_json_simple.py`
- `pytest -q`
