### PR TITLE
Add declarative LLM router

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example API keys for llm_router usage
+OPENAI_API_KEY=""
+ANTHROPIC_API_KEY=""
+GOOGLE_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Our method outperforms strong baselines on both Paper2Code and PaperBench and pr
 - [📚 Detailed Setup Instructions](#-detailed-setup-instructions)
 - [📦 Paper2Code Benchmark Datasets](#-paper2code-benchmark-datasets)
 - [📊 Model-based Evaluation of Repositories](#-model-based-evaluation-of-repositories-generated-by-papercoder)
+- [🔀 LLM Router](#-llm-router)
 
 ---
 
@@ -272,6 +273,22 @@ python eval.py \
 💵 Current total cost: $0.16451380
 🪙 Accumulated total cost so far: $0.16451380
 ============================================
+```
+
+## 🔀 LLM Router
+The router configuration lives in [`llm_router/config.yaml`](./llm_router/config.yaml).
+
+| Task Pattern | Primary Model | Fallback |
+|--------------|--------------|---------|
+| `chat\|faq\|rag` | `gemini_flash_25` | `claude_sonnet_35` |
+| `code\|unit_tests` | `claude_sonnet_37` | `o4mini` |
+| `long_doc>300k` | `gpt41` | `claude_sonnet_35` |
+| `tool_reasoning` | `o4mini` | `gemini_flash_25` |
+
+Override the config by setting `LLM_CFG`:
+
+```bash
+export LLM_CFG=/path/to/custom.yaml
 ```
 
 ## 💵 Official AI Model API Pricing (May 2025)

--- a/llm_router/config.yaml
+++ b/llm_router/config.yaml
@@ -1,0 +1,50 @@
+defaults:
+  max_retry: 3
+  timeout_sec: 60          # fail-fast
+
+models:
+  gemini_flash_25:
+    provider: google
+    price_per_mtok: 0.75
+    speed_tps: 380
+    context: 1_000_000
+    strengths: [realtime, multimodal, thinking]
+  claude_sonnet_35:
+    provider: anthropic
+    price_per_mtok: 18
+    speed_tps: 120
+    context: 200_000
+    strengths: [stable_reasoning, artifacts]
+  claude_sonnet_37:
+    provider: anthropic
+    price_per_mtok: 18
+    speed_tps: 110
+    context: 200_000
+    strengths: [coding, tests]
+  o4mini:
+    provider: openai
+    price_per_mtok: 5.50
+    speed_tps: 156
+    context: 200_000
+    strengths: [tool_calls, structured_reasoning]
+  gpt41:
+    provider: openai
+    price_per_mtok: 10       # 2 in + 8 out
+    speed_tps: 100
+    context: 1_000_000
+    strengths: [long_context]
+
+routing_rules:
+  chat|faq|rag:
+    primary: gemini_flash_25
+    fallback: claude_sonnet_35
+  code|unit_tests:
+    primary: claude_sonnet_37
+    fallback: o4mini
+  long_doc>300k:
+    primary: gpt41
+    fallback: claude_sonnet_35
+  tool_reasoning:
+    primary: o4mini
+    fallback: gemini_flash_25
+

--- a/llm_router/router.py
+++ b/llm_router/router.py
@@ -1,0 +1,48 @@
+import os
+import yaml
+from functools import lru_cache
+
+CONFIG_PATH = os.environ.get("LLM_CFG", "llm_router/config.yaml")
+
+@lru_cache
+def _load_cfg():
+    with open(CONFIG_PATH) as f:
+        return yaml.safe_load(f)
+
+def choose_model(task: str, *, tokens: int = 0):
+    cfg = _load_cfg()
+    rules = cfg["routing_rules"]
+
+    for pattern, rule in rules.items():
+        name, *cond = pattern.split(">")
+        if name in task:
+            if cond and tokens <= int(cond[0]):   # long_doc
+                continue
+            return rule["primary"]
+    raise ValueError("No routing rule found")
+
+def wrap_call(task, prompt, **kw):
+    m_id = choose_model(task, tokens=len(str(prompt))//4)
+    try:
+        return _call(m_id, prompt, **kw)
+    except Exception as e:
+        for _ in range(_load_cfg()["defaults"]["max_retry"]):
+            m_id = _load_cfg()["routing_rules"][task]["fallback"]
+            try:
+                return _call(m_id, prompt, **kw)
+            except Exception:
+                continue
+        raise e  # escalate
+
+def _call(model_id, prompt, **kw):
+    # Unified interface
+    if model_id.startswith("gemini"):
+        import google.generativeai as genai
+        return genai.chat(model=model_id, messages=[prompt], **kw)
+    elif model_id.startswith("claude"):
+        import anthropic
+        client = anthropic.Anthropic()
+        return client.messages.create(model=model_id, messages=[{"role": "user", "content": prompt}], **kw)
+    else:  # openai
+        import openai
+        return openai.ChatCompletion.create(model=model_id, messages=[{"role": "user", "content": prompt}], **kw)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-openai>=1.65.4
+openai>=1,<2
+anthropic>=1,<2
+google-generativeai>=0.5,<0.6
 vllm>=0.6.4.post1
 transformers>=4.46.3
 tiktoken>=0.9.0

--- a/tasks/pdf_to_json.py
+++ b/tasks/pdf_to_json.py
@@ -1,0 +1,22 @@
+from llm_router.router import wrap_call
+
+
+def pdf_to_json(path):
+    imgs = pdf_to_images(path)
+    out = []
+    for img in imgs:
+        j = wrap_call(
+            task="rag",
+            prompt={"image": img, "text": "Extract structured JSON"},
+            temperature=0,
+        )
+        out.append(j)
+    return merge_pages(out)
+
+
+def pdf_to_images(path):
+    raise NotImplementedError("placeholder")
+
+
+def merge_pages(pages):
+    raise NotImplementedError("placeholder")


### PR DESCRIPTION
## Summary
- pin open-source LLM packages
- add generic LLM router with config
- document router usage in README
- provide placeholder tasks directory
- add example `.env` for API keys

## Testing
- `pytest -q`