### PR TITLE
Add router tests and dynamic config loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example API keys for llm_router usage
+OPENAI_API_KEY=""
+ANTHROPIC_API_KEY=""
+GOOGLE_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Our method outperforms strong baselines on both Paper2Code and PaperBench and pr
 - [📚 Detailed Setup Instructions](#-detailed-setup-instructions)
 - [📦 Paper2Code Benchmark Datasets](#-paper2code-benchmark-datasets)
 - [📊 Model-based Evaluation of Repositories](#-model-based-evaluation-of-repositories-generated-by-papercoder)
+- [🔀 LLM Router](#-llm-router)
 
 ---
 
@@ -273,6 +274,23 @@ python eval.py \
 🪙 Accumulated total cost so far: $0.16451380
 ============================================
 ```
+
+## 🔀 LLM Router
+The router configuration lives in [`llm_router/config.yaml`](./llm_router/config.yaml).
+
+| Task Pattern | Primary Model | Fallback |
+|--------------|--------------|---------|
+| `chat\|faq\|rag` | `gemini_flash_25` | `claude_sonnet_35` |
+| `code\|unit_tests` | `claude_sonnet_37` | `o4mini` |
+| `long_doc>300k` | `gpt41` | `claude_sonnet_35` |
+| `tool_reasoning` | `o4mini` | `gemini_flash_25` |
+
+Override the config by setting `LLM_CFG`:
+
+```bash
+export LLM_CFG=/path/to/custom.yaml
+```
+If `PyYAML` is unavailable, the router falls back to a minimal built-in parser.
 
 ## 💵 Official AI Model API Pricing (May 2025)
 

--- a/llm_router/config.yaml
+++ b/llm_router/config.yaml
@@ -1,0 +1,50 @@
+defaults:
+  max_retry: 3
+  timeout_sec: 60          # fail-fast
+
+models:
+  gemini_flash_25:
+    provider: google
+    price_per_mtok: 0.75
+    speed_tps: 380
+    context: 1_000_000
+    strengths: [realtime, multimodal, thinking]
+  claude_sonnet_35:
+    provider: anthropic
+    price_per_mtok: 18
+    speed_tps: 120
+    context: 200_000
+    strengths: [stable_reasoning, artifacts]
+  claude_sonnet_37:
+    provider: anthropic
+    price_per_mtok: 18
+    speed_tps: 110
+    context: 200_000
+    strengths: [coding, tests]
+  o4mini:
+    provider: openai
+    price_per_mtok: 5.50
+    speed_tps: 156
+    context: 200_000
+    strengths: [tool_calls, structured_reasoning]
+  gpt41:
+    provider: openai
+    price_per_mtok: 10       # 2 in + 8 out
+    speed_tps: 100
+    context: 1_000_000
+    strengths: [long_context]
+
+routing_rules:
+  chat|faq|rag:
+    primary: gemini_flash_25
+    fallback: claude_sonnet_35
+  code|unit_tests:
+    primary: claude_sonnet_37
+    fallback: o4mini
+  long_doc>300k:
+    primary: gpt41
+    fallback: claude_sonnet_35
+  tool_reasoning:
+    primary: o4mini
+    fallback: gemini_flash_25
+

--- a/llm_router/router.py
+++ b/llm_router/router.py
@@ -1,0 +1,105 @@
+import os
+from functools import lru_cache
+
+try:  # optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback if PyYAML missing
+    yaml = None
+
+
+def _parse_tokens(text: str) -> int:
+    """Return integer token count from shorthand like '300k' or '1_000'."""
+    text = text.replace('_', '').lower()
+    mul = 1
+    if text.endswith('k'):
+        mul = 1000
+        text = text[:-1]
+    elif text.endswith('m'):
+        mul = 1_000_000
+        text = text[:-1]
+    return int(float(text) * mul)
+
+
+def _simple_yaml_load(text: str) -> dict:
+    """Very small YAML loader supporting a subset of the syntax."""
+    data: dict = {}
+    stack = [(0, data)]
+    for raw in text.splitlines():
+        if not raw.strip() or raw.lstrip().startswith('#'):
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        key, _, val = raw.lstrip().partition(':')
+        key = key.strip()
+        val = val.strip()
+        while stack and indent < stack[-1][0]:
+            stack.pop()
+        current = stack[-1][1]
+        if val == '':
+            new: dict = {}
+            current[key] = new
+            stack.append((indent + 2, new))
+            continue
+        if val.startswith('[') and val.endswith(']'):
+            items = [v.strip() for v in val[1:-1].split(',') if v.strip()]
+            current[key] = items
+            continue
+        try:
+            current[key] = _parse_tokens(val)
+        except Exception:
+            if val.lower() in {'true', 'false'}:
+                current[key] = val.lower() == 'true'
+            else:
+                current[key] = val
+    return data
+
+
+@lru_cache
+def _load_cfg():
+    path = os.environ.get("LLM_CFG", "llm_router/config.yaml")
+    with open(path) as f:
+        raw = f.read()
+    if yaml:
+        return yaml.safe_load(raw)
+    return _simple_yaml_load(raw)
+
+def choose_model(task: str, *, tokens: int = 0) -> str:
+    cfg = _load_cfg()
+    rules = cfg["routing_rules"]
+
+    for pattern, rule in rules.items():
+        name_part, *cond = pattern.split(">")
+        names = name_part.split("|")
+        if not any(n in task for n in names):
+            continue
+        if cond:
+            limit = _parse_tokens(cond[0])
+            if tokens <= limit:
+                continue
+        return rule["primary"]
+    raise ValueError("No routing rule found")
+
+def wrap_call(task, prompt, **kw):
+    m_id = choose_model(task, tokens=len(str(prompt))//4)
+    try:
+        return _call(m_id, prompt, **kw)
+    except Exception as e:
+        for _ in range(_load_cfg()["defaults"]["max_retry"]):
+            m_id = _load_cfg()["routing_rules"][task]["fallback"]
+            try:
+                return _call(m_id, prompt, **kw)
+            except Exception:
+                continue
+        raise e  # escalate
+
+def _call(model_id, prompt, **kw):
+    # Unified interface
+    if model_id.startswith("gemini"):
+        import google.generativeai as genai
+        return genai.chat(model=model_id, messages=[prompt], **kw)
+    elif model_id.startswith("claude"):
+        import anthropic
+        client = anthropic.Anthropic()
+        return client.messages.create(model=model_id, messages=[{"role": "user", "content": prompt}], **kw)
+    else:  # openai
+        import openai
+        return openai.ChatCompletion.create(model=model_id, messages=[{"role": "user", "content": prompt}], **kw)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-openai>=1.65.4
+openai>=1,<2
+anthropic>=1,<2
+google-generativeai>=0.5,<0.6
+PyYAML>=6.0
 vllm>=0.6.4.post1
 transformers>=4.46.3
 tiktoken>=0.9.0
@@ -7,3 +10,4 @@ camelot-py>=0.11
 pdf2image>=1.16.3
 PyMuPDF>=1.23.7
 pytesseract>=0.3.10
+

--- a/tasks/pdf_to_json.py
+++ b/tasks/pdf_to_json.py
@@ -1,0 +1,22 @@
+from llm_router.router import wrap_call
+
+
+def pdf_to_json(path):
+    imgs = pdf_to_images(path)
+    out = []
+    for img in imgs:
+        j = wrap_call(
+            task="rag",
+            prompt={"image": img, "text": "Extract structured JSON"},
+            temperature=0,
+        )
+        out.append(j)
+    return merge_pages(out)
+
+
+def pdf_to_images(path):
+    raise NotImplementedError("placeholder")
+
+
+def merge_pages(pages):
+    raise NotImplementedError("placeholder")

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,60 @@
+import os
+import sys
+from pathlib import Path
+import importlib
+
+import pytest
+
+# Ensure repo root on path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from llm_router import router
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    router._load_cfg.cache_clear()
+    yield
+    router._load_cfg.cache_clear()
+
+
+def make_cfg(tmp_path: Path) -> Path:
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        """defaults:\n  max_retry: 2\nrouting_rules:\n  foo:\n    primary: m1\n    fallback: m2\n  long>10k:\n    primary: big\n    fallback: small\n"""
+    )
+    return cfg
+
+
+def test_choose_model_basic(tmp_path, monkeypatch):
+    cfg_path = make_cfg(tmp_path)
+    monkeypatch.setenv("LLM_CFG", str(cfg_path))
+    assert router.choose_model("foo") == "m1"
+    assert router.choose_model("long", tokens=20000) == "big"
+    with pytest.raises(ValueError):
+        router.choose_model("missing")
+
+
+def test_env_override(tmp_path, monkeypatch):
+    cfg_path = make_cfg(tmp_path)
+    monkeypatch.setenv("LLM_CFG", str(cfg_path))
+    assert router.choose_model("foo") == "m1"
+
+
+def test_wrap_call_fallback(tmp_path, monkeypatch):
+    cfg_path = make_cfg(tmp_path)
+    monkeypatch.setenv("LLM_CFG", str(cfg_path))
+    calls = []
+
+    def fake_call(mid, prompt, **kw):
+        calls.append(mid)
+        if mid == "m1":
+            raise RuntimeError("fail")
+        return "ok"
+
+    monkeypatch.setattr(router, "_call", fake_call)
+    out = router.wrap_call("foo", "hi")
+    assert out == "ok"
+    assert calls == ["m1", "m2"]
+


### PR DESCRIPTION
## Summary
- support dynamic `LLM_CFG` by reading it during config load
- implement minimal YAML loader for environments without PyYAML
- parse token thresholds like `300k`
- document fallback YAML parser
- add unit tests for router selection and fallback
- add `PyYAML` to requirements

## Testing
- `pytest -q`