### PR TITLE
Add declarative LLM router

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example API keys for llm_router usage
+OPENAI_API_KEY=""
+ANTHROPIC_API_KEY=""
+GOOGLE_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Our method outperforms strong baselines on both Paper2Code and PaperBench and pr
 - [📚 Detailed Setup Instructions](#-detailed-setup-instructions)
 - [📦 Paper2Code Benchmark Datasets](#-paper2code-benchmark-datasets)
 - [📊 Model-based Evaluation of Repositories](#-model-based-evaluation-of-repositories-generated-by-papercoder)
+- [🔀 LLM Router](#-llm-router)
 
 ---
 
@@ -272,6 +273,22 @@ python eval.py \
 💵 Current total cost: $0.16451380
 🪙 Accumulated total cost so far: $0.16451380
 ============================================
+```
+
+## 🔀 LLM Router
+The router configuration lives in [`llm_router/config.yaml`](./llm_router/config.yaml).
+
+| Task Pattern | Primary Model | Fallback |
+|--------------|--------------|---------|
+| `chat\|faq\|rag` | `gemini_flash_25` | `claude_sonnet_35` |
+| `code\|unit_tests` | `claude_sonnet_37` | `o4mini` |
+| `long_doc>300k` | `gpt41` | `claude_sonnet_35` |
+| `tool_reasoning` | `o4mini` | `gemini_flash_25` |
+
+Override the config by setting `LLM_CFG`:
+
+```bash
+export LLM_CFG=/path/to/custom.yaml
 ```
 
 ## 💵 Official AI Model API Pricing (May 2025)

--- a/llm_router/config.yaml
+++ b/llm_router/config.yaml
@@ -1,0 +1,50 @@
+defaults:
+  max_retry: 3
+  timeout_sec: 60          # fail-fast
+
+models:
+  gemini_flash_25:
+    provider: google
+    price_per_mtok: 0.75
+    speed_tps: 380
+    context: 1_000_000
+    strengths: [realtime, multimodal, thinking]
+  claude_sonnet_35:
+    provider: anthropic
+    price_per_mtok: 18
+    speed_tps: 120
+    context: 200_000
+    strengths: [stable_reasoning, artifacts]
+  claude_sonnet_37:
+    provider: anthropic
+    price_per_mtok: 18
+    speed_tps: 110
+    context: 200_000
+    strengths: [coding, tests]
+  o4mini:
+    provider: openai
+    price_per_mtok: 5.50
+    speed_tps: 156
+    context: 200_000
+    strengths: [tool_calls, structured_reasoning]
+  gpt41:
+    provider: openai
+    price_per_mtok: 10       # 2 in + 8 out
+    speed_tps: 100
+    context: 1_000_000
+    strengths: [long_context]
+
+routing_rules:
+  chat|faq|rag:
+    primary: gemini_flash_25
+    fallback: claude_sonnet_35
+  code|unit_tests:
+    primary: claude_sonnet_37
+    fallback: o4mini
+  long_doc>300k:
+    primary: gpt41
+    fallback: claude_sonnet_35
+  tool_reasoning:
+    primary: o4mini
+    fallback: gemini_flash_25
+

--- a/llm_router/router.py
+++ b/llm_router/router.py
@@ -1,0 +1,122 @@
+import os
+try:
+    import yaml
+except Exception:
+    yaml = None
+from functools import lru_cache
+
+CONFIG_PATH = os.environ.get("LLM_CFG", "llm_router/config.yaml")
+
+def _simple_yaml(text: str) -> dict:
+    data = {}
+    stack = [data]
+    indents = [0]
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        while indent < indents[-1]:
+            stack.pop()
+            indents.pop()
+        key, _, val = line.lstrip().partition(":")
+        val = val.strip()
+        if not val:
+            new = {}
+            stack[-1][key] = new
+            stack.append(new)
+            indents.append(indent + 2)
+        else:
+            if val.startswith("[") and val.endswith("]"):
+                items = [v.strip() for v in val[1:-1].split(",") if v.strip()]
+                stack[-1][key] = items
+            else:
+                v = val.replace("_", "").lower()
+                mult = 1
+                if v.endswith("k"):
+                    mult = 1000
+                    v = v[:-1]
+                elif v.endswith("m"):
+                    mult = 1000000
+                    v = v[:-1]
+                try:
+                    num = float(v)
+                    if num.is_integer():
+                        stack[-1][key] = int(num * mult)
+                    else:
+                        stack[-1][key] = num * mult
+                    continue
+                except ValueError:
+                    pass
+                stack[-1][key] = val
+    return data
+
+@lru_cache
+def _load_cfg():
+    with open(CONFIG_PATH) as f:
+        text = f.read()
+    if yaml is not None:
+        return yaml.safe_load(text)
+    return _simple_yaml(text)
+
+def _parse_num(txt: str) -> int:
+    txt = txt.replace("_", "").lower()
+    mult = 1
+    if txt.endswith("k"):
+        mult = 1000
+        txt = txt[:-1]
+    elif txt.endswith("m"):
+        mult = 1000000
+        txt = txt[:-1]
+    return int(float(txt) * mult)
+
+def _find_rule(task: str, tokens: int = 0):
+    cfg = _load_cfg()
+    for pattern, rule in cfg["routing_rules"].items():
+        name, *cond = pattern.split(">")
+        names = name.split("|")
+        if any(n and n in task for n in names):
+            if cond:
+                threshold = _parse_num(cond[0])
+                if tokens <= threshold:
+                    continue
+            return rule
+    return None
+
+
+def choose_model(task: str, *, tokens: int = 0):
+    rule = _find_rule(task, tokens)
+    if not rule:
+        raise ValueError("No routing rule found")
+    return rule["primary"]
+
+def wrap_call(task, prompt, **kw):
+    tokens = len(str(prompt)) // 4
+    rule = _find_rule(task, tokens)
+    if not rule:
+        raise ValueError("No routing rule found")
+    m_id = rule["primary"]
+    try:
+        return _call(m_id, prompt, **kw)
+    except Exception as e:
+        for _ in range(_load_cfg()["defaults"]["max_retry"]):
+            m_id = rule.get("fallback")
+            if not m_id:
+                break
+            try:
+                return _call(m_id, prompt, **kw)
+            except Exception:
+                continue
+        raise e  # escalate
+
+def _call(model_id, prompt, **kw):
+    # Unified interface
+    if model_id.startswith("gemini"):
+        import google.generativeai as genai
+        return genai.chat(model=model_id, messages=[prompt], **kw)
+    elif model_id.startswith("claude"):
+        import anthropic
+        client = anthropic.Anthropic()
+        return client.messages.create(model=model_id, messages=[{"role": "user", "content": prompt}], **kw)
+    else:  # openai
+        import openai
+        return openai.ChatCompletion.create(model=model_id, messages=[{"role": "user", "content": prompt}], **kw)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-openai>=1.65.4
+openai>=1,<2
+anthropic>=1,<2
+google-generativeai>=0.5,<0.6
 vllm>=0.6.4.post1
 transformers>=4.46.3
 tiktoken>=0.9.0

--- a/tasks/pdf_to_json.py
+++ b/tasks/pdf_to_json.py
@@ -1,0 +1,22 @@
+from llm_router.router import wrap_call
+
+
+def pdf_to_json(path):
+    imgs = pdf_to_images(path)
+    out = []
+    for img in imgs:
+        j = wrap_call(
+            task="rag",
+            prompt={"image": img, "text": "Extract structured JSON"},
+            temperature=0,
+        )
+        out.append(j)
+    return merge_pages(out)
+
+
+def pdf_to_images(path):
+    raise NotImplementedError("placeholder")
+
+
+def merge_pages(pages):
+    raise NotImplementedError("placeholder")

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+import llm_router.router as router
+
+CFG_PATH = os.path.join(os.path.dirname(__file__), "..", "llm_router", "config.yaml")
+
+
+def reload_router(monkeypatch, cfg_path=CFG_PATH, no_yaml=False):
+    monkeypatch.setenv("LLM_CFG", cfg_path)
+    if no_yaml:
+        monkeypatch.setattr(router, "yaml", None, raising=False)
+    importlib.reload(router)
+
+
+def test_choose_model_patterns(monkeypatch):
+    reload_router(monkeypatch)
+    assert router.choose_model("unit_tests") == "claude_sonnet_37"
+    assert router.choose_model("chat") == "gemini_flash_25"
+
+
+def test_choose_model_threshold(monkeypatch):
+    reload_router(monkeypatch)
+    with pytest.raises(ValueError):
+        router.choose_model("long_doc", tokens=1000)
+    assert router.choose_model("long_doc", tokens=400000) == "gpt41"
+
+
+def test_wrap_call_uses_fallback(monkeypatch):
+    reload_router(monkeypatch)
+    calls = []
+
+    def fake_call(model, prompt, **kw):
+        calls.append(model)
+        if model == "claude_sonnet_37":
+            raise RuntimeError
+        return "ok"
+
+    monkeypatch.setattr(router, "_call", fake_call)
+    out = router.wrap_call("code", "hello")
+    assert out == "ok"
+    assert calls == ["claude_sonnet_37", "o4mini"]
+
+
+def test_fallback_yaml_loader(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.yaml"
+    cfg.write_text("""defaults:\n  max_retry: 1\nrouting_rules:\n  test:\n    primary: A\n    fallback: B\n""")
+    reload_router(monkeypatch, str(cfg), no_yaml=True)
+    assert router.choose_model("test") == "A"
+


### PR DESCRIPTION
## Summary
- pin open-source LLM packages
- add generic LLM router with config
- document router usage in README
- provide placeholder tasks directory
- add example `.env` for API keys
- improve router rule parsing and fallback logic
- add tests for the new router

## Testing
- `pytest -q`
